### PR TITLE
Use `uname -m` instead of `uname -i`

### DIFF
--- a/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
+++ b/modules/ROOT/pages/updates-upgrades-rollbacks.adoc
@@ -49,7 +49,7 @@ You can print all available branches for {variant-name} with this command:
 
 [source,bash,subs="attributes"]
 ----
-$ ostree remote refs fedora | grep {variant} | grep $(uname -i)
+$ ostree remote refs fedora | grep {variant} | grep $(uname -m)
 ----
 
 After you've verified the name of your branch, you are ready to proceed.


### PR DESCRIPTION
On Fedora 38 Kinoite uname -i prints 'unknown', whereas '-m' prints 'x86_64'. I haven't tested Silverblue, but I expect that apart from the choice of desktop environment the base system is identical and thus `uname` would behave the same way. Fixes https://github.com/fedora-silverblue/silverblue-docs/issues/163

This is the silverblue variant of https://pagure.io/fedora-kde/kinoite-docs/pull-request/11